### PR TITLE
TASK: compatibility with Neos 9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "email": "support@flownative.com"
     },
     "require": {
-        "neos/neos": "^5.3 || ^7.0 || ^8.0",
+        "neos/neos": "^5.3 || ^7.0 || ^8.0 || ^8.0 || dev-master",
         "flownative/openidconnect-client": "^3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "email": "support@flownative.com"
     },
     "require": {
-        "neos/neos": "^5.3 || ^7.0 || ^8.0 || ^8.0 || dev-master",
+        "neos/neos": "^5.3 || ^7.0 || ^8.0 || ^9.0 || dev-master",
         "flownative/openidconnect-client": "^3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "email": "support@flownative.com"
     },
     "require": {
-        "neos/neos": "^5.3 || ^7.0 || ^8.0 || ^9.0 || dev-master",
+        "neos/neos": "^5.3 || ^7.0 || ^8.0 || ^9.0 || dev-main",
         "flownative/openidconnect-client": "^3.0"
     },
     "autoload": {


### PR DESCRIPTION
For updating to Neos 9.0 the version needs to be pulled up.

As far as I can see on my local machine the package works fine with Neos 9.0. Perhaps someone else can verify with a Neos 9.0 installation.