### PR TITLE
Do not persist changes to account

### DIFF
--- a/Classes/AccountManager.php
+++ b/Classes/AccountManager.php
@@ -174,6 +174,9 @@ class AccountManager
         // The $oidcCredentialSource it is too large to be actually persisted to the database field
         $account->setCredentialsSource($oidcCredentialSource);
         $account->setRoles($assignedRoles);
+        
+        $this->persistenceManager->clearState();
+        
         return $account;
     }
 


### PR DESCRIPTION
closes #5 

Apparently we do not want changes to our account be persisted, but with the user saving it is persisted. 

I hope clearing the persistence manager will solve the problem while still remembering the stuff in the cookie. 

For testing I have tested on local with the following steps:

- Login and Logout 
- Changing my own user account: Adding Editor permissions 
- Changing my own user account: Removing Admin permissions, Adding Editor and Neos User Manager permissions 
- Changing other user accounts: Changing Name & Permissions 
- Changing / saving content in live workspace 